### PR TITLE
Set a custom message for missing implicit 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -171,7 +171,8 @@ lazy val examples = crossProject(JSPlatform, JVMPlatform, NativePlatform).crossT
   .settings(moduleName := "simulacrum-examples")
   .settings(noPublishSettings: _*)
   .platformsSettings(JVMPlatform, JSPlatform)(
-    libraryDependencies += scalatest.value
+    libraryDependencies += scalatest.value,
+    libraryDependencies += "com.chuusai" %%% "shapeless" % "2.3.3" % "test"
   )
   .nativeSettings(
     nativeCommonSettings

--- a/examples/.jvm/src/test/scala/simulacrum/jvm-examples/examples.scala
+++ b/examples/.jvm/src/test/scala/simulacrum/jvm-examples/examples.scala
@@ -1,0 +1,21 @@
+package simulacrum.jvmexamples
+
+import simulacrum._
+import shapeless.test.illTyped
+
+import org.scalatest.{ WordSpec, Matchers }
+
+class Examples extends WordSpec with Matchers {
+
+  "the @typeclass annotation" should {
+
+    "Return the correct error message for missing implicit" in {
+      @typeclass trait Semigroup[A] {
+        @op("|+|") def append(x: A, y: A): A
+      }
+
+      illTyped("Semigroup[Float]", "Could not find an instance of Semigroup for Float")
+    }
+  }
+}
+


### PR DESCRIPTION
Currently the user sees the generic "implicit not found" message from Scala if no implicit exist in the context, this PR will provide a more user-friendly message.

Fixes https://github.com/typelevel/simulacrum/issues/37