### PR TITLE
Add support for Scala Native 0.4.0-M2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 .idea
 .bloop
 .metals
+lowered.hnir

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ language: scala
 
 scala:
   - "2.11.12"
-  - "2.12.8"
-  - "2.13.0"
+  - "2.12.10"
+  - "2.13.1"
 
 jdk:
   - openjdk8
@@ -27,6 +27,13 @@ matrix:
   include:
   - sudo: required
     scala: SCALA_NATIVE
+    before_install:
+    - curl https://raw.githubusercontent.com/scala-native/scala-native/cddb41c2ded4da4/scripts/travis_setup.sh | bash -x
+    script:
+    - sbt coreNative/test examplesNative/test
+  - sudo: required
+    scala: SCALA_NATIVE
+    env: SCALANATIVE_VERSION="0.4.0-M2"
     before_install:
     - curl https://raw.githubusercontent.com/scala-native/scala-native/cddb41c2ded4da4/scripts/travis_setup.sh | bash -x
     script:

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val commonSettings = Seq(
   scalacOptions in (Compile, console) ~= { _ filterNot { o => o == "-Ywarn-unused-import" || o == "-Xfatal-warnings" } },
   scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
   scalaVersion := Scala211,
-  crossScalaVersions := Seq(Scala211, "2.12.8", "2.13.0"),
+  crossScalaVersions := Seq(Scala211, "2.12.10", "2.13.0"),
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),
     Resolver.sonatypeRepo("snapshots")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,13 @@
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.29")
+val scalaNativeVersion =
+  Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.3.9")
+
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.0")
-addSbtPlugin("org.scala-js" % "sbt-scalajs"  % "0.6.29")
+addSbtPlugin("org.scala-js" % "sbt-scalajs"  % scalaJSVersion)
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.3")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.1")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % scalaNativeVersion)


### PR DESCRIPTION
This PR adds support for Scala Native 0.4.0-M2.
The CI will test the two versions but for the release process you'll have to manually release the 0.4.0-M2 version using:
```bash
SCALANATIVE_VERSION="0.4.0-M2" sbt "coreNative/publish"
```