### PR TITLE
Stop @typeclass warn for implicit conversions

### DIFF
--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -426,6 +426,7 @@ class TypeClassMacros(val c: Context) {
       val companion = q"""
         $mods object $name extends ..$bases {
           ..$body
+          import _root_.scala.language.implicitConversions
           $summoner
           ..$opsMembers
         }


### PR DESCRIPTION
If you neither set the '-language:implicitConversions' flag, nor the 'import scala.language.implicitConversions', the '@typeclass' construct warns for implicit conversions.

I've tried, and this PR prevents it.