### PR TITLE
Fix Scala.js clash between Ops trait and ops object on Mac OS

### DIFF
--- a/core/src/main/scala/simulacrum/typeclass.scala
+++ b/core/src/main/scala/simulacrum/typeclass.scala
@@ -419,7 +419,7 @@ class TypeClassMacros(val c: Context) {
       val opsMembers: List[Tree] = {
         val ops = List(opsTrait, toOpsTrait, nonInheritedOpsConversion)
         val allOps = if (typeClassArguments.generateAllOps) List(allOpsTrait, allOpsConversion) else Nil
-        ops ++ allOps
+        allOps ++ ops
       }
 
       val q"$mods object $name extends ..$bases { ..$body }" = comp


### PR DESCRIPTION
See scala/bug#11997 and scala/scala#9035